### PR TITLE
Cleanup Neovim configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
     - DIVE: "${HOME}/dive"
     - CI: "true"
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install python3
+
 install:
   - curl -sLo ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
   - curl -sL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.tar.gz" | tar zx --directory ${HOME} && chmod 700 ${DIVE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ before_install:
 install:
   - curl -sLo ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
   - curl -sL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.tar.gz" | tar zx --directory ${HOME} && chmod 700 ${DIVE}
+  - pip3 install vim-vint
+
 script:
   - shellcheck scripts/*
+  - vint nvim/*.vim
   - ${HADOLINT} Dockerfile
   - docker build -t jswny/dotfiles . && ${DIVE} jswny/dotfiles
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install python3
+  - sudo apt-get install python3 python3-pip
 
 install:
   - curl -sLo ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install python3 python3-pip
+  - sudo apt-get install python3 python3-pip python3-setuptools
 
 install:
   - curl -sLo ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}

--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,5 @@
+cmdargs:
+  severity: style_problem
+  color: true
+  env:
+    neovim: true

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -214,7 +214,7 @@ let g:lightline = {
 \ }
 
 " Show the filename and the modified state in a single Lightline component
-function! LightlineFilename()
+function! g:LightlineFilename()
   let l:filename = expand('%:t') !=# '' ? expand('%:t') : '[No Name]'
   let l:modified = &modified ? ' +' : ''
   return l:filename . l:modified
@@ -232,12 +232,12 @@ function! s:LCNVCountType(type)
 endfunction
 
 " LanguageClient-Neovim warning count
-function! LCNVWarningCount()
+function! g:LCNVWarningCount()
   return s:LCNVCountType('W')
 endfunction
 
 " LanguageClient-Neovim error count
-function! LCNVErrorCount()
+function! g:LCNVErrorCount()
   return s:LCNVCountType('E')
 endfunction
 
@@ -329,7 +329,7 @@ augroup lcnv_bindings
 augroup END
 
 " Echo an arbitrary warning message
-function! EchoWarning(msg)
+function! s:EchoWarning(msg)
   echohl WarningMsg
   echo a:msg
   echohl None
@@ -339,7 +339,7 @@ endfunction
 function s:VerifyTypeScriptTSXConfigExists()
   let l:currentDirectoryPath = getcwd()
   if empty(findfile(glob('tsconfig.json'), l:currentDirectoryPath.';'))
-    call EchoWarning('You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.')
+    call s:EchoWarning('You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.')
   endif
 endfunction()
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -62,7 +62,7 @@ nnoremap <leader>l :Lines<cr>
 " Specify a directory for plugins
 " - For Neovim: $HOME/.local/share/nvim/plugged
 " - Avoid using standard Vim directory names like 'plugin'
-call plug#begin(xdg_data_home.'/nvim/plugged')
+call plug#begin(g:xdg_data_home.'/nvim/plugged')
 
 " Editing
 Plug 'tpope/vim-endwise'
@@ -73,7 +73,7 @@ Plug 'alvan/vim-closetag'
 " Utilities
 Plug 'tpope/vim-fugitive'
 Plug 'airblade/vim-gitgutter'
-Plug xdg_data_home.'/fzf'
+Plug g:xdg_data_home.'/fzf'
 Plug 'junegunn/fzf.vim'
 Plug 'tpope/vim-dispatch'
 Plug 'janko-m/vim-test'
@@ -213,18 +213,18 @@ let g:lightline = {
 function! LightlineFilename()
   let l:filename = expand('%:t') !=# '' ? expand('%:t') : '[No Name]'
   let l:modified = &modified ? ' +' : ''
-  return filename . modified
+  return l:filename . l:modified
 endfunction
 
-" Define a function which returns a string with the count of a specific type of LanguageClient-Neovim diagnostic
+" Returns a string with the count of a specific type of LanguageClient-Neovim diagnostic
 " This function gets its results from quickfix
 " `type` is a string that is either `'W'` (warning) or `'E'` (error)
 function! s:LCNVCountType(type)
   let l:current_buf_number = bufnr('%')
   let l:qflist = getqflist()
-  let l:current_buf_diagnostics = filter(qflist, {index, dict -> dict['bufnr'] == current_buf_number && dict['type'] == a:type})
-  let l:count = len(current_buf_diagnostics)
-  return count > 0 && g:LanguageClient_loaded ? a:type . ': ' . count : ''
+  let l:current_buf_diagnostics = filter(l:qflist, {index, dict -> dict['bufnr'] == l:current_buf_number && dict['type'] == a:type})
+  let l:count = len(l:current_buf_diagnostics)
+  return l:count > 0 && g:LanguageClient_loaded ? a:type . ': ' . l:count : ''
 endfunction
 
 " Define a function for the LanguageClient-Neovim warning count
@@ -272,7 +272,7 @@ let g:float_preview#docked = 1
 " LanguageClient-Neovim "
 """""""""""""""""""""""""
 
-let g:LanguageClient_loggingFile = expand(xdg_cache_home.'/nvim/LanguageClient.log')
+let g:LanguageClient_loggingFile = expand(g:xdg_cache_home.'/nvim/LanguageClient.log')
 
 " Enable debugging
 let g:LanguageClient_loggingLevel = 'DEBUG'
@@ -297,7 +297,7 @@ let g:LanguageClient_serverCommands = {
 let g:LanguageClient_diagnosticsSignsMax = 0
 
 " Set the location for LCNV to load settings from
-let g:LanguageClient_settingsPath = xdg_config_home.'/nvim/lcnv-settings.json'
+let g:LanguageClient_settingsPath = g:xdg_config_home.'/nvim/lcnv-settings.json'
 
 " Use the LanguageClient-Neovim key bindings in appropriate file buffers only to avoid breaking normal functionality
 function s:SetLCNVKeyBindings()
@@ -327,8 +327,8 @@ endfunction
 
 " Check if a tsconfig.json file can be found by recursively searching up parent directories (until the root directory). Print a warning if one is not found
 function VerifyTypeScriptTSXConfigExists()
-  let currentDirectoryPath = getcwd()
-  if empty(findfile(glob("tsconfig.json"), currentDirectoryPath.';'))
+  let l:currentDirectoryPath = getcwd()
+  if empty(findfile(glob("tsconfig.json"), l:currentDirectoryPath.';'))
     call EchoWarning("You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.")
   endif
 endfunction()

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -21,6 +21,27 @@
 " Set the script encoding (for multibyte characters) (http://rbtnn.hateblo.jp/entry/2014/12/28/010913)
 scriptencoding utf-8
 
+"""""""""""""""""""""""""
+" Environment Variables "
+"""""""""""""""""""""""""
+if !empty($XDG_CONFIG_HOME)
+  let g:xdg_config_home = $XDG_CONFIG_HOME
+else
+  let g:xdg_config_home = '$HOME/.config'
+endif
+
+if !empty($XDG_DATA_HOME)
+  let g:xdg_data_home = $XDG_DATA_HOME
+else
+  let g:xdg_data_home = '$HOME/.local/share'
+endif
+
+if !empty($XDG_CACHE_HOME)
+  let g:xdg_cache_home = $XDG_CACHE_HOME
+else
+  let g:xdg_cache_home = '$HOME/.cache'
+endif
+
 """"""""""""""""
 " Key Bindings "
 """"""""""""""""
@@ -38,14 +59,8 @@ nnoremap <leader>l :Lines<cr>
 " Plugins "
 """""""""""
 
-if !empty($XDG_DATA_HOME)
-  let g:xdg_data_home = $XDG_DATA_HOME
-else
-  let g:xdg_data_home = '~/.local/share'
-endif
-
 " Specify a directory for plugins
-" - For Neovim: ~/.local/share/nvim/plugged
+" - For Neovim: $HOME/.local/share/nvim/plugged
 " - Avoid using standard Vim directory names like 'plugin'
 call plug#begin(xdg_data_home.'/nvim/plugged')
 
@@ -257,7 +272,7 @@ let g:float_preview#docked = 1
 " LanguageClient-Neovim "
 """""""""""""""""""""""""
 
-let g:LanguageClient_loggingFile = expand('~/.cache/nvim/LanguageClient.log')
+let g:LanguageClient_loggingFile = expand(xdg_cache_home.'/nvim/LanguageClient.log')
 
 " Enable debugging
 let g:LanguageClient_loggingLevel = 'DEBUG'
@@ -282,7 +297,7 @@ let g:LanguageClient_serverCommands = {
 let g:LanguageClient_diagnosticsSignsMax = 0
 
 " Set the location for LCNV to load settings from
-let g:LanguageClient_settingsPath = '~/.config/nvim/lcnv-settings.json'
+let g:LanguageClient_settingsPath = xdg_config_home.'/nvim/lcnv-settings.json'
 
 " Use the LanguageClient-Neovim key bindings in appropriate file buffers only to avoid breaking normal functionality
 function s:SetLCNVKeyBindings()

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -219,7 +219,7 @@ endfunction
 " Returns a string with the count of a specific type of LanguageClient-Neovim diagnostic
 " This function gets its results from quickfix
 " `type` is a string that is either `'W'` (warning) or `'E'` (error)
-function! s:LCNVCountType(type)
+function! s:LCNVCountType(a:type)
   let l:current_buf_number = bufnr('%')
   let l:qflist = getqflist()
   let l:current_buf_diagnostics = filter(l:qflist, {index, dict -> dict['bufnr'] == l:current_buf_number && dict['type'] == a:type})
@@ -319,7 +319,7 @@ augroup LSP
 augroup END
 
 " Echo an arbitrary warning message
-function! EchoWarning(msg)
+function! EchoWarning(a:msg)
   echohl WarningMsg
   echo a:msg
   echohl None

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -62,7 +62,7 @@ nnoremap <leader>l :Lines<cr>
 " Specify a directory for plugins
 " - For Neovim: $HOME/.local/share/nvim/plugged
 " - Avoid using standard Vim directory names like 'plugin'
-call plug#begin(g:xdg_data_home.'/nvim/plugged')
+call plug#begin(g:xdg_data_home . '/nvim/plugged')
 
 " Editing
 Plug 'tpope/vim-endwise'
@@ -73,7 +73,7 @@ Plug 'alvan/vim-closetag'
 " Utilities
 Plug 'tpope/vim-fugitive'
 Plug 'airblade/vim-gitgutter'
-Plug g:xdg_data_home.'/fzf'
+Plug g:xdg_data_home . '/fzf'
 Plug 'junegunn/fzf.vim'
 Plug 'tpope/vim-dispatch'
 Plug 'janko-m/vim-test'
@@ -282,7 +282,7 @@ let g:float_preview#docked = 1
 " LanguageClient-Neovim "
 """""""""""""""""""""""""
 
-let g:LanguageClient_loggingFile = expand(g:xdg_cache_home.'/nvim/LanguageClient.log')
+let g:LanguageClient_loggingFile = expand(g:xdg_cache_home . '/nvim/LanguageClient.log')
 
 " Enable debugging
 let g:LanguageClient_loggingLevel = 'DEBUG'
@@ -307,7 +307,7 @@ let g:LanguageClient_serverCommands = {
 let g:LanguageClient_diagnosticsSignsMax = 0
 
 " Set the location for LCNV to load settings from
-let g:LanguageClient_settingsPath = g:xdg_config_home.'/nvim/lcnv-settings.json'
+let g:LanguageClient_settingsPath = g:xdg_config_home . '/nvim/lcnv-settings.json'
 
 " Use the LanguageClient-Neovim key bindings in appropriate file buffers only to avoid breaking normal functionality
 function s:SetLCNVKeyBindings()
@@ -338,7 +338,7 @@ endfunction
 " Check if a tsconfig.json file can be found by recursively searching up parent directories (until the root directory). Print a warning if one is not found
 function s:VerifyTypeScriptTSXConfigExists()
   let l:currentDirectoryPath = getcwd()
-  if empty(findfile(glob('tsconfig.json'), l:currentDirectoryPath.';'))
+  if empty(findfile(glob('tsconfig.json'), l:currentDirectoryPath . ';'))
     call s:EchoWarning('You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.')
   endif
 endfunction()

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -160,7 +160,7 @@ augroup quit_on_quickfix
 augroup END
 
 function! QuitIfQuickfixLastWindow()
-  if &buftype=="quickfix"
+  if &buftype =~? 'quickfix'
     " If this window is last on screen quit without warning
     if winbufnr(2) == -1
       quit!
@@ -250,10 +250,16 @@ let g:deoplete#enable_at_startup = 1
 
 " Automatically close the Deoplete preview window after completion
 " (https://github.com/Shougo/deoplete.nvim/issues/115)
-autocmd InsertLeave,CompleteDone * if pumvisible() == 0 | pclose | endif
+augroup close_deoplete_after_completion
+  autocmd!
+  autocmd InsertLeave,CompleteDone * if pumvisible() == 0 | pclose | endif
+augroup END
 
 " Disable Deoplete for markdown files
-autocmd bufread,bufnewfile *.md call deoplete#disable()
+augroup disable_deoplete_markdown
+  autocmd!
+  autocmd bufread,bufnewfile *.md call deoplete#disable()
+augroup END
 
 """""""""""
 " Echodoc "
@@ -332,8 +338,8 @@ endfunction
 " Check if a tsconfig.json file can be found by recursively searching up parent directories (until the root directory). Print a warning if one is not found
 function VerifyTypeScriptTSXConfigExists()
   let l:currentDirectoryPath = getcwd()
-  if empty(findfile(glob("tsconfig.json"), l:currentDirectoryPath.';'))
-    call EchoWarning("You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.")
+  if empty(findfile(glob('tsconfig.json'), l:currentDirectoryPath.';'))
+    call EchoWarning('You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.')
   endif
 endfunction()
 
@@ -348,7 +354,7 @@ augroup END
 """"""""""""
 
 " Tell Vim Test to use Dispatch Vim as the testing strategy
-let g:test#strategy = "dispatch"
+let g:test#strategy = 'dispatch'
 
 """"""""""""
 " Vim JSON "

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -170,7 +170,7 @@ endfunction
 
 " Automatically update folds on file open and after leaving insert mode
 " in order to fix folding in Elixir files
-augroup ElixirFixFolds
+augroup elixir_fix_folds
   autocmd!
   autocmd FileType elixir normal! zXzR
   autocmd FileType elixir autocmd InsertLeave * normal! zXzR
@@ -317,7 +317,7 @@ function s:SetLCNVKeyBindings()
   nnoremap <leader>lm :call LanguageClient_contextMenu()<CR>
 endfunction()
 
-augroup LSP
+augroup lcnv_bindings
   autocmd!
   autocmd FileType elixir,python,typescript,typescript.tsx,json,rust call s:SetLCNVKeyBindings()
 augroup END
@@ -337,7 +337,7 @@ function VerifyTypeScriptTSXConfigExists()
   endif
 endfunction()
 
-augroup LSPVerifyTSXConfig
+augroup lsp_verify_tsx_config
   autocmd!
   " The unsilent part needed in order to echo messages with a FileType autocmd (https://gitter.im/neovim/neovim?at=5db6863be886fb5aa20b6808)
   autocmd FileType typescript.tsx unsilent call VerifyTypeScriptTSXConfigExists()

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -41,7 +41,6 @@ else
   let g:xdg_data_home = '~/.local/share'
 endif
 
-
 " Specify a directory for plugins
 " - For Neovim: ~/.local/share/nvim/plugged
 " - Avoid using standard Vim directory names like 'plugin'
@@ -316,7 +315,6 @@ function VerifyTypeScriptTSXConfigExists()
     call EchoWarning("You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.")
   endif
 endfunction()
-
 
 augroup LSPVerifyTSXConfig
   autocmd!

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -219,7 +219,7 @@ endfunction
 " Returns a string with the count of a specific type of LanguageClient-Neovim diagnostic
 " This function gets its results from quickfix
 " `type` is a string that is either `'W'` (warning) or `'E'` (error)
-function! s:LCNVCountType(a:type)
+function! s:LCNVCountType(type)
   let l:current_buf_number = bufnr('%')
   let l:qflist = getqflist()
   let l:current_buf_diagnostics = filter(l:qflist, {index, dict -> dict['bufnr'] == l:current_buf_number && dict['type'] == a:type})
@@ -319,7 +319,7 @@ augroup LSP
 augroup END
 
 " Echo an arbitrary warning message
-function! EchoWarning(a:msg)
+function! EchoWarning(msg)
   echohl WarningMsg
   echo a:msg
   echohl None

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -18,6 +18,9 @@
 " For the FZF plugin:
 " - FZF installed (https://github.com/junegunn/fzf) in the path specified in the plugin definition below
 
+" Set the script encoding (for multibyte characters) (http://rbtnn.hateblo.jp/entry/2014/12/28/010913)
+scriptencoding utf-8
+
 """"""""""""""""
 " Key Bindings "
 """"""""""""""""
@@ -136,11 +139,10 @@ set pumheight=10
 """"""""""""""
 
 " Automatically quit Vim if quickfix is the last open window
-autocmd BufEnter * call MyLastWindow()
-function! MyLastWindow()
-  " if the window is quickfix go on
+autocmd BufEnter * call QuitIfQuickfixLastWindow()
+function! QuitIfQuickfixLastWindow()
   if &buftype=="quickfix"
-    " if this window is last on screen quit without warning
+    " If this window is last on screen quit without warning
     if winbufnr(2) == -1
       quit!
     endif
@@ -184,16 +186,16 @@ let g:lightline = {
 \                [ 'lcnverrors', 'lcnvwarnings', 'filetype' ], ],
 \   },
 \   'component_function': {
-\     'filename': 'Lightline_filename',
+\     'filename': 'LightlineFilename',
 \     'gitbranch': 'fugitive#head',
-\     'lcnvwarnings': 'LCNV_warning_count',
-\     'lcnverrors': 'LCNV_error_count',
+\     'lcnvwarnings': 'LCNVWarningCount',
+\     'lcnverrors': 'LCNVErrorCount',
 \     'venv': 'virtualenv#statusline',
 \   },
 \ }
 
-" Define a function to show the filename and the modified state in a single component
-function! Lightline_filename()
+" Show the filename and the modified state in a single Lightline component
+function! LightlineFilename()
   let filename = expand('%:t') !=# '' ? expand('%:t') : '[No Name]'
   let modified = &modified ? ' +' : ''
   return filename . modified
@@ -202,7 +204,7 @@ endfunction
 " Define a function which returns a string with the count of a specific type of LanguageClient-Neovim diagnostic
 " This function gets its results from quickfix
 " `type` is a string that is either `'W'` (warning) or `'E'` (error)
-function! s:LCNV_count_type(type)
+function! s:LCNVCountType(type)
   let current_buf_number = bufnr('%')
   let qflist = getqflist()
   let current_buf_diagnostics = filter(qflist, {index, dict -> dict['bufnr'] == current_buf_number && dict['type'] == a:type})
@@ -211,13 +213,13 @@ function! s:LCNV_count_type(type)
 endfunction
 
 " Define a function for the LanguageClient-Neovim warning count
-function! LCNV_warning_count()
-  return s:LCNV_count_type('W')
+function! LCNVWarningCount()
+  return s:LCNVCountType('W')
 endfunction
 
 " Define a function for the LanguageClient-Neovim error count
-function! LCNV_error_count()
-  return s:LCNV_count_type('E')
+function! LCNVErrorCount()
+  return s:LCNVCountType('E')
 endfunction
 
 """"""""""""

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -176,7 +176,7 @@ augroup END
 """"""""""""""""""
 
 " Add a space for all comments
-let NERDSpaceDelims=1
+let g:NERDSpaceDelims=1
 
 """"""""""""""""
 " Vim Closetag "
@@ -211,8 +211,8 @@ let g:lightline = {
 
 " Show the filename and the modified state in a single Lightline component
 function! LightlineFilename()
-  let filename = expand('%:t') !=# '' ? expand('%:t') : '[No Name]'
-  let modified = &modified ? ' +' : ''
+  let l:filename = expand('%:t') !=# '' ? expand('%:t') : '[No Name]'
+  let l:modified = &modified ? ' +' : ''
   return filename . modified
 endfunction
 
@@ -220,10 +220,10 @@ endfunction
 " This function gets its results from quickfix
 " `type` is a string that is either `'W'` (warning) or `'E'` (error)
 function! s:LCNVCountType(type)
-  let current_buf_number = bufnr('%')
-  let qflist = getqflist()
-  let current_buf_diagnostics = filter(qflist, {index, dict -> dict['bufnr'] == current_buf_number && dict['type'] == a:type})
-  let count = len(current_buf_diagnostics)
+  let l:current_buf_number = bufnr('%')
+  let l:qflist = getqflist()
+  let l:current_buf_diagnostics = filter(qflist, {index, dict -> dict['bufnr'] == current_buf_number && dict['type'] == a:type})
+  let l:count = len(current_buf_diagnostics)
   return count > 0 && g:LanguageClient_loaded ? a:type . ': ' . count : ''
 endfunction
 
@@ -344,7 +344,7 @@ augroup END
 """"""""""""
 
 " Tell Vim Test to use Dispatch Vim as the testing strategy
-let test#strategy = "dispatch"
+let g:test#strategy = "dispatch"
 
 """"""""""""
 " Vim JSON "

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -156,10 +156,10 @@ set pumheight=10
 " Automatically quit Vim if quickfix is the last open window
 augroup quit_on_quickfix
   autocmd!
-  autocmd BufEnter * call QuitIfQuickfixLastWindow()
+  autocmd BufEnter * call s:QuitIfQuickfixLastWindow()
 augroup END
 
-function! QuitIfQuickfixLastWindow()
+function! s:QuitIfQuickfixLastWindow()
   if &buftype =~? 'quickfix'
     " If this window is last on screen quit without warning
     if winbufnr(2) == -1
@@ -231,12 +231,12 @@ function! s:LCNVCountType(type)
   return l:count > 0 && g:LanguageClient_loaded ? a:type . ': ' . l:count : ''
 endfunction
 
-" Define a function for the LanguageClient-Neovim warning count
+" LanguageClient-Neovim warning count
 function! LCNVWarningCount()
   return s:LCNVCountType('W')
 endfunction
 
-" Define a function for the LanguageClient-Neovim error count
+" LanguageClient-Neovim error count
 function! LCNVErrorCount()
   return s:LCNVCountType('E')
 endfunction
@@ -336,7 +336,7 @@ function! EchoWarning(msg)
 endfunction
 
 " Check if a tsconfig.json file can be found by recursively searching up parent directories (until the root directory). Print a warning if one is not found
-function VerifyTypeScriptTSXConfigExists()
+function s:VerifyTypeScriptTSXConfigExists()
   let l:currentDirectoryPath = getcwd()
   if empty(findfile(glob('tsconfig.json'), l:currentDirectoryPath.';'))
     call EchoWarning('You are opening a TSX file but no tsconfig.json could be found. TSX language server support requires a tsconfig.json file which specifies that TSX should be enabled.')
@@ -346,7 +346,7 @@ endfunction()
 augroup lsp_verify_tsx_config
   autocmd!
   " The unsilent part needed in order to echo messages with a FileType autocmd (https://gitter.im/neovim/neovim?at=5db6863be886fb5aa20b6808)
-  autocmd FileType typescript.tsx unsilent call VerifyTypeScriptTSXConfigExists()
+  autocmd FileType typescript.tsx unsilent call s:VerifyTypeScriptTSXConfigExists()
 augroup END
 
 """"""""""""

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -154,7 +154,11 @@ set pumheight=10
 """"""""""""""
 
 " Automatically quit Vim if quickfix is the last open window
-autocmd BufEnter * call QuitIfQuickfixLastWindow()
+augroup quit_on_quickfix
+  autocmd!
+  autocmd BufEnter * call QuitIfQuickfixLastWindow()
+augroup END
+
 function! QuitIfQuickfixLastWindow()
   if &buftype=="quickfix"
     " If this window is last on screen quit without warning

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -10,7 +10,7 @@
 " - Neovim Python3 provider (pip3 install pynvim)
 " - Neovim installed from HEAD
 " For LanguageClient_Neovim, the following available in $PATH:
-" - ElixirLS (https://github.com/JakeBecker/elixir-ls) or (https://github.com/elixir-lsp/elixir-ls)
+" - ElixirLS with `language_server.sh` as `elixir-ls` (https://github.com/elixir-lsp/elixir-ls)
 " - PyLS (ideally with all add-ons) available in (https://github.com/palantir/python-language-server)
 " - Sourcegraph JavaScript/TypeScript Language Server (https://github.com/sourcegraph/javascript-typescript-langserver)
 " - VSCode JSON Language server (https://github.com/vscode-langservers/vscode-json-languageserver)
@@ -269,7 +269,7 @@ let g:LanguageClient_rootMarkers = {
 
 " Setup individual Language Servers from $PATH
 let g:LanguageClient_serverCommands = {
-\   'elixir': ['elixir-ls.sh'],
+\   'elixir': ['elixir-ls'],
 \   'python': ['pyls'],
 \   'typescript': ['javascript-typescript-stdio'],
 \   'typescript.tsx': ['javascript-typescript-stdio'],


### PR DESCRIPTION
Clean up Neovim configuration in `init.vim`.

Closes #7.

- [x] Spacing issues
- [x] Function naming
- [x] Function scoping
- [x] Variable naming
- [x] Variable scoping
- [x] Augroup naming
- [x] Vint errors
- [x] Other style guide items
- [x] Usages of `~` instead of `$HOME`
- [x] Hardcoded XDG values
